### PR TITLE
api: update port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ ENV DATABASE_URL=mysql+pymysql://dbuser:dbuser@dnyf-group-db:3306/dnyf-group-db
 
 # During debugging, this entry point will be overridden. For more information, please refer to https://aka.ms/vscode-docker-python-debug
 # CMD ["gunicorn", "--bind", "0.0.0.0:8000", "-k", "uvicorn.workers.UvicornWorker", "src.app:app"]
-CMD [ "python3", "-m", "uvicorn", "src.app:app", "--reload", "--host=0.0.0.0" ]
+CMD [ "python3", "-m", "uvicorn", "src.app:app", "--reload", "--host=0.0.0.0", "--port=8101" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: ./Dockerfile
     ports:
-      - 8000:8000
+      - 8101:8101
     volumes:
       - ./:/app
     networks:


### PR DESCRIPTION
Change port to 8101 to avoid potential conflicts when running other microservices locally.